### PR TITLE
fix: Install works when prefix/manprefix directories does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test:
 	./test.sh
 
 install:
+	mkdir -p $(PREFIX)/bin $(MANPREFIX)
 	cp rtail.sh $(PREFIX)/bin/$(BIN)
 	cp rtail.1 $(MANPREFIX)/$(BIN).1
 


### PR DESCRIPTION
I came across this error when trying a clean install of bpkg - I didn't have `~/.local/share/...` created